### PR TITLE
Update fixes

### DIFF
--- a/crontab.sauce
+++ b/crontab.sauce
@@ -20,7 +20,7 @@
 # For more information see the manual pages of crontab(5) and cron(8)
 #
 # m h  dom mon dow   command
-*/5 * * * * unzip /home/sauce/slack-export.zip -d /home/sauce/slack-export
+*/5 * * * * unzip -o /home/sauce/slack-export.zip -d /home/sauce/slack-export
 0 0 * * * bash -c 'for i in $(ls -d slack-export/*/); do /home/sauce/venv/bin/python /home/sauce/slacktalker/parse_words.py $(ls $i*); done' >> /tmp/slack-import-words.log 2>&1
 */5 * * * * bash -c '/home/sauce/venv/bin/python /home/sauce/slacktalker/parse_users.py /home/sauce/slack-export/users.json' >> /tmp/slack-import-users.log 2>&1
 0 */3 * * * bash -c 'cd /home/sauce/slacktalker && ./launch_uwsgi.sh'

--- a/make_sentence.py
+++ b/make_sentence.py
@@ -47,7 +47,7 @@ def make_sentence(username, prompt=""):
         word = session.query(model.WordEntry)\
             .filter(model.WordEntry.user == user.id, model.WordEntry.word_prev == prompt)\
             .order_by(func.rand()).first()
-    if word:
+    elif word:
         sentence += word.word_prev + " "
     else:
         word = session.query(model.WordEntry)\

--- a/parse_words.py
+++ b/parse_words.py
@@ -110,6 +110,13 @@ if __name__ == '__main__':
                 .format(filename, last_loaded, channel)
         else:
             print "Parsing file: {}".format(filename)
-            parse_file(filename)
+            try:
+                parse_file(filename)
+            except Exception as e:
+                # possible errors when previous parsing was interrupted
+                print "Found error. Doing a session rollback"
+                print e
+                session.rollback()
+                continue
             set_last_loaded(channel, date)
             save_memory()


### PR DESCRIPTION
A few things went wrong when I tried to update slacktalker with a fresh Slack export. This makes them go right.

The crontab was missing `-o` for unzip, which was fine for the uniquely named channel files, but not for `users.json`.

I had ctrl+c'd a manual parsing run while debugging, which screwed everything up until I added a `session.rollback()` as the exception suggested.

And I noticed an extra space was being included whenever saucy was given the sentence's beginning word. Also fixed.